### PR TITLE
Explicitly set the IdentityAgent path when using the `issue` mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func processCommand() int {
 			// override default ssh-agent socket
 			os.Setenv("SSH_AUTH_SOCK", agent.SocketFile())
 			log.Debugf("set SSH_AUTH_SOCK to %q\n", agent.SocketFile())
+			sshClient.PrependArgs([]string{"-o", "IdentityAgent=SSH_AUTH_SOCK"})
 
 		case "sign":
 			signedKey, err := vaultClient.SignKey(sshClient.User)


### PR DESCRIPTION
This make sure the appropriate path is used even if the IdentityAgent is set in a config.

Without this change a user with the following config will not be able to connect because the SSH_AUTH_SOCK env variable will be overriden:
```
Host *
	IdentityAgent none
	IdentityFile ~/.ssh/id_ecdsa_sk
```